### PR TITLE
Add Octo STS policy for releases workflow

### DIFF
--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -6,5 +6,6 @@ subject: repo:chainguard-dev/advisory-schema:ref:refs/tags/v.*
 claim_pattern:
   job_workflow_ref: chainguard-dev/advisory-schema/.github/workflows/release.yaml@.*
 
+# the release workflow needs write permissions to push tags
 permissions:
   contents: write


### PR DESCRIPTION
The release workflow needs permission to create tags.

As mentioned on [the GitHub documentation](https://docs.github.com/en/rest/git/tags?apiVersion=2022-11-28#create-a-tag-object--fine-grained-access-tokens
), the "Contents" repository permission (write) is required.