### PR TITLE
Allow signed commits

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -1,0 +1,13 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+ spec:
+   authorities:
+     - keyless:
+         # allow commits signed by users using GitHub or Google OIDC
+         identities:
+           - issuer: https://accounts.google.com
+           - issuer: https://github.com/login/oauth
+     - key:
+         # allow commits signed by GitHub, e.g. the UI
+         kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
Add Chainguard source file to allow commits signed by:
- users using GitHub or Google OIDC
- GitHub the UI