### PR TITLE
Add release job

### DIFF
--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 issuer: https://token.actions.githubusercontent.com
-subject: repo:chainguard-dev/advisory-schema:ref:refs/tags/v.*
+subject: repo:chainguard-dev/advisory-schema:ref:refs/heads/main
 claim_pattern:
-  job_workflow_ref: chainguard-dev/advisory-schema/.github/workflows/release.yaml@.*
+  job_workflow_ref: chainguard-dev/advisory-schema/.github/workflows/release.yaml@refs/heads/main
 
-# the release workflow needs write permissions to push tags
+# the release workflow needs write permissions to create and push tags
 permissions:
   contents: write
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,6 @@ on:
     - cron: '0 0 * * 1' # weekly on Monday at 00:00
   workflow_dispatch:
 
-permissions:
 permissions: {}
 
 jobs:
@@ -17,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      id-token: write # to inject the OIDC token to octo-sts
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
- automatically create weekly tagged patch releases if any code has changed since previous release
- releases can be manually run as necessary
- use octo-sts to get the token to create the tags