### PR TITLE
Trigger releases manually only

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,8 +4,9 @@
 name: release
 
 on:
-  schedule:
-    - cron: '0 0 * * 1' # weekly on Monday at 00:00
+  # disabled weekly releases 
+  #schedule:
+  #  - cron: '0 0 * * 1' # weekly on Monday at 00:00
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
For the time being, since the repo is private and the content is not fully complete, disable the automated weekly release workflow